### PR TITLE
feat: show letter candidates in notes tabs

### DIFF
--- a/src/client/cards/CardPile.tsx
+++ b/src/client/cards/CardPile.tsx
@@ -36,7 +36,10 @@ export const CardPile = (props: Props) => {
       <Pile>
         <CardOnPile letter={null} />
       </Pile>
-      <Tooltip title={`There are ${numCards} cards in this pile.`}>
+      <Tooltip
+        title={`There are ${numCards} cards in this pile.`}
+        PopperProps={{ disablePortal: true }}
+      >
         <CardQuantity>
           <img src={cardQuantity} alt={`Pile of ${numCards} cards`} />
           <CardQuantityNumber>{numCards}</CardQuantityNumber>

--- a/src/client/display/NonPlayerDisplay.tsx
+++ b/src/client/display/NonPlayerDisplay.tsx
@@ -38,7 +38,10 @@ export const NonPlayerDisplay = (props: Props) => {
           <DisplayName>Non-player {nonPlayerIndex + 1}</DisplayName>
           {numLettersRemaining > 0 && (
             <Hints>
-              <Tooltip title="This hint becomes available once this non-player pile is exhausted.">
+              <Tooltip
+                title="This hint becomes available once this non-player pile is exhausted."
+                PopperProps={{ disablePortal: true }}
+              >
                 <Hint src={LockedHint} alt="Locked hint" />
               </Tooltip>
             </Hints>

--- a/src/client/display/PlayerHints.tsx
+++ b/src/client/display/PlayerHints.tsx
@@ -27,6 +27,7 @@ export const PlayerHints = (props: Props) => {
         <Tooltip
           key={`${playerID}-used-${i}`}
           title={`This hint was used by ${playerName}.`}
+          PopperProps={{ disablePortal: true }}
         >
           <Hint src={UsedHint} alt="Used hint" />
         </Tooltip>
@@ -35,6 +36,7 @@ export const PlayerHints = (props: Props) => {
         <Tooltip
           key={`${playerID}-unused-${i}`}
           title={`This hint is available only to ${playerName}.`}
+          PopperProps={{ disablePortal: true }}
         >
           <Hint src={UnusedHint} alt="Unused hint" />
         </Tooltip>
@@ -42,6 +44,7 @@ export const PlayerHints = (props: Props) => {
       {hintsUnused === 0 && teamHintsAvailable > 0 && (
         <Tooltip
           title={`${playerName} can still give a clue by using one of the team's shared hints.`}
+          PopperProps={{ disablePortal: true }}
         >
           <Hint src={AvailableHint} alt="Available hint" />
         </Tooltip>

--- a/src/client/display/TeamDisplay.tsx
+++ b/src/client/display/TeamDisplay.tsx
@@ -26,6 +26,7 @@ export const TeamDisplay = (props: Props) => {
             <Tooltip
               key={`available-${i}`}
               title="This hint is available to players that have used all of their own hints."
+              PopperProps={{ disablePortal: true }}
             >
               <Hint src={AvailableHint} alt="Available hint" />
             </Tooltip>
@@ -34,6 +35,7 @@ export const TeamDisplay = (props: Props) => {
             <Tooltip
               key={`locked-${i}`}
               title="This hint becomes available once every player uses all of their own hints."
+              PopperProps={{ disablePortal: true }}
             >
               <Hint src={LockedHint} alt="Locked hint" />
             </Tooltip>

--- a/src/client/display/TeamDisplay.tsx
+++ b/src/client/display/TeamDisplay.tsx
@@ -2,8 +2,8 @@ import _ from "lodash";
 import { Tooltip } from "@mui/material";
 
 import { Letter, TeamHints } from "../../game/types";
-import AvailableHint from "../assets/hints/available.svg";
 import LockedHint from "../assets/hints/locked.svg";
+import UnusedHint from "../assets/hints/unused.svg";
 import { PresentedCard } from "../cards/PresentedCard";
 import { DisplayCell, DisplayStatus, DisplayName } from "./DisplayCell";
 import { Hints, Hint } from "./hint";
@@ -24,11 +24,11 @@ export const TeamDisplay = (props: Props) => {
         <Hints>
           {_.range(teamHints.available).map((_, i) => (
             <Tooltip
-              key={`available-${i}`}
+              key={`unused-${i}`}
               title="This hint is available to players that have used all of their own hints."
               PopperProps={{ disablePortal: true }}
             >
-              <Hint src={AvailableHint} alt="Available hint" />
+              <Hint src={UnusedHint} alt="Unused hint" />
             </Tooltip>
           ))}
           {_.range(teamHints.locked).map((_, i) => (

--- a/src/client/panels/LetterNotes.tsx
+++ b/src/client/panels/LetterNotes.tsx
@@ -50,6 +50,22 @@ export const LetterNotes = (props: Props) => {
     () => props.notes[letterIndex],
     [props.notes, letterIndex]
   );
+  const getLetterTabLabel = useCallback(
+    (i: number) => {
+      const notes = props.notes[i];
+      const candidates = _.keys(_.pickBy(notes, (value) => value));
+      let candidatesLabel = "";
+      if (candidates.length > 3) {
+        const [firstCandidate, secondCandidate] = candidates;
+        candidatesLabel = ` (${firstCandidate}, ${secondCandidate}, ...)`;
+      } else if (candidates.length > 0) {
+        candidatesLabel = ` (${candidates.join(", ")})`;
+      }
+
+      return `${getOrdinalSuffix(i + 1)} Letter${candidatesLabel}`;
+    },
+    [props.notes]
+  );
   const onUpdateNote = useCallback(
     (e: React.MouseEvent<HTMLElement>, char: Letter) => {
       props.onUpdateNote(letterIndex, char, !activeNotes[char]);
@@ -66,7 +82,7 @@ export const LetterNotes = (props: Props) => {
           onChange={(_, newTab) => setLetterIndex(newTab)}
         >
           {props.notes.map((_, i) => (
-            <LetterTab key={i} label={`${getOrdinalSuffix(i + 1)} Letter`} />
+            <LetterTab key={i} label={getLetterTabLabel(i)} />
           ))}
         </Tabs>
       </LetterNotesTabs>


### PR DESCRIPTION
Also includes fixes and improvements to hints, which hopefully addresses some confusion new users have been having:
- fix: restore tooltips
- present: display team hints as unused hints